### PR TITLE
Extend iso9660.D1Characters. Add warning on files with unusual characters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ will run without any external library on target system.
 
 * Write protection. Enabled by default, use flag `--allow-write` or corresponding parameter.
 * TCP data exchange timeouts / auto-close of idle connections: configured by `--read-timeout` parameter.
-* [Compressed images](#compressed-images) - save your disk space without filesystem-level compression.
+* [Compressed images](#compressed-images) - save your disk space without filesystem-level compression. Note: PSP images are not supported now: https://github.com/xakep666/ps3netsrv-go/issues/37
 * Built-in client: see `ps3netsrv-go client --help`
 
 ### Supported ✅

--- a/cmd/ps3netsrv-go/server.go
+++ b/cmd/ps3netsrv-go/server.go
@@ -10,6 +10,8 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
@@ -183,8 +185,23 @@ func (sapp *serverApp) warnRoot() {
 	}
 }
 
-func (sapp *serverApp) warnLargeDir() {
+func (sapp *serverApp) scanAndWarn() {
 	const maxEntries = 4096 // from ps3netsrv
+
+	// notify user if file name can cause access issues
+	const allowedChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_ !\"%&'()*+,-./:;<=>?[]"
+	var allowedCharsSet [256]bool
+	for _, char := range allowedChars {
+		allowedCharsSet[char] = true
+	}
+
+	const maxBadNames = 10
+	badNameSamples := make([]string, 0, maxBadNames)
+	isBadName := func(name string) bool {
+		return strings.ContainsFunc(name, func(r rune) bool {
+			return r > rune(len(allowedCharsSet)) || !allowedCharsSet[r]
+		})
+	}
 
 	queue := []string{sapp.Root}
 	scanDir := func(path string) {
@@ -206,6 +223,11 @@ func (sapp *serverApp) warnLargeDir() {
 
 			numEntries += len(entries)
 			for _, entry := range entries {
+				if len(badNameSamples) <= maxBadNames && isBadName(entry.Name()) {
+					relPath := filepath.Join(strings.TrimPrefix(path, sapp.Root), entry.Name())
+					badNameSamples = append(badNameSamples, strconv.Quote(relPath))
+				}
+
 				if entry.IsDir() {
 					queue = append(queue, filepath.Join(path, entry.Name()))
 				}
@@ -223,6 +245,12 @@ func (sapp *serverApp) warnLargeDir() {
 		queue = queue[:len(queue)-1]
 
 		scanDir(dir)
+	}
+
+	if len(badNameSamples) > 0 {
+		slog.Warn("Found files/directories with names containing unusual characters. These files can cause issues with WebMan Mod or other software on a console. Consider inspecting your collection and renaming files.",
+			"allowed_characters", allowedChars, "name_examples", badNameSamples,
+		)
 	}
 }
 
@@ -243,7 +271,7 @@ func (sapp *serverApp) Run() error {
 	sapp.setupLogger()
 	sapp.setupRuntime()
 	sapp.warnRoot()
-	go sapp.warnLargeDir() // asynchronously to not delay server startup
+	go sapp.scanAndWarn() // asynchronously to not delay server startup
 
 	var eg errgroup.Group
 	eg.Go(sapp.debugServer)

--- a/internal/iso9660/iso9660.go
+++ b/internal/iso9660/iso9660.go
@@ -27,11 +27,8 @@ const (
 	VolumeTypePartition     byte = 3
 	VolumeTypeTerminator    byte = 255
 
-	ACharacters StringA = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_!\"%&'()*+,-./:;<=>?"
+	ACharacters StringA = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_ !\"%&'()*+,-./:;<=>?"
 	DCharacters StringD = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
-	// ECMA-119 7.4.2.2 defines d1-characters as
-	// "subject to agreement between the originator and the recipient of the volume".
-	D1Characters StringD1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_!\"%&'()*+,-./:;<=>?"
 )
 
 const (
@@ -59,14 +56,6 @@ var (
 	dCharactersSet = sync.OnceValue(func() map[rune]struct{} {
 		m := make(map[rune]struct{}, len(DCharacters))
 		for _, r := range DCharacters {
-			m[r] = struct{}{}
-		}
-		return m
-	})
-
-	d1CharactersSet = sync.OnceValue(func() map[rune]struct{} {
-		m := make(map[rune]struct{}, len(D1Characters))
-		for _, r := range D1Characters {
 			m[r] = struct{}{}
 		}
 		return m
@@ -101,8 +90,11 @@ func (b SizeBytes) Sectors() SizeSectors {
 }
 
 type (
-	StringA  string
-	StringD  string
+	StringA string
+	StringD string
+	// ECMA-119 7.4.2.2 defines d1-characters as
+	// "subject to agreement between the originator and the recipient of the volume".
+	// We don't put special restrictions here.
 	StringD1 string
 )
 
@@ -440,15 +432,7 @@ func MangleStringD(in string, joliet bool) StringD {
 }
 
 func MangleStringD1(in string, joliet bool) StringD1 {
-	set := d1CharactersSet()
-	ret := strings.Map(func(r rune) rune {
-		if _, ok := set[r]; ok {
-			return r
-		}
-
-		return '_'
-	}, in)
-
+	ret := in
 	if joliet {
 		ret, _ = utf16Encoder.String(ret)
 	}


### PR DESCRIPTION
Fixes (partially) #37 