### PR TITLE
Lowercase ghcr owner for docker image name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ archives:
         strip_parent: true
 dockers_v2:
   - images:
-      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/ps3netsrv-go"
+      - "ghcr.io/{{ tolower .Env.GITHUB_REPOSITORY_OWNER }}/ps3netsrv-go"
     tags:
       - "v{{ .Version }}"
       - "v{{ .Major }}.{{ .Minor }}"


### PR DESCRIPTION
This is not a problem for the upstream repo, since the repo owner name is already in all lowercase. But in my fork it causes Docker images to fail to publish.
```
  • publishing
    • docker images (v2)
      • creating images                              id=ps3netsrv-go
        images=
        │ ghcr.io/CatMe0w/ps3netsrv-go:latest
        │ ghcr.io/CatMe0w/ps3netsrv-go:v0.4
        │ ghcr.io/CatMe0w/ps3netsrv-go:v0.4.1-fork.1
  ⨯ release failed after 1m43s                       error=docker images (v2): failed to publish artifacts: exit status 1 message=could not build docker image args=docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/CatMe0w/ps3netsrv-go:latest -t ghcr.io/CatMe0w/ps3netsrv-go:v0.4 -t ghcr.io/CatMe0w/ps3netsrv-go:v0.4.1-fork.1 --push --attest=type=sbom --iidfile=id.txt --label org.opencontainers.image.created=2026-06-15T06:51:57Z --label org.opencontainers.image.licenses=MIT --label org.opencontainers.image.revision=c40458918f1ab33fa586c5e889c1d3444406f188 --label org.opencontainers.image.source=https://github.com/CatMe0w/ps3netsrv-go --label org.opencontainers.image.title=ps3netsrv-go --label org.opencontainers.image.version=v0.4.1-fork.1 . id=ps3netsrv-go
    output=
    │ ERROR: failed to build: invalid tag "ghcr.io/CatMe0w/ps3netsrv-go:latest": repository name must be lowercase
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.16.0/x64/goreleaser' failed with exit code 1
```
Add `tolower` as an explicit guard.