### PR TITLE
Fix Windows CHD support

### DIFF
--- a/.github/workflows/libchdr.yml
+++ b/.github/workflows/libchdr.yml
@@ -68,15 +68,18 @@ jobs:
           build-args: |
             --target chdr
       - name: Install complied libs
-        # 'tar' to preserve a symlinks
-        # unpack .a archives for windows (idk why cmake archives dll)
+        # 'tar' to preserve symlinks for versioned .so/.dylib files
         run: |
+          export BUILDDIR="${{ github.workspace }}/build"
           export DISTDIR="${{ github.workspace }}/dist"
-          export LIBDIR="$DISTDIR/lib"
-          mkdir -p "$DISTDIR"
-          cmake --install "${{ github.workspace }}/build" --prefix "$DISTDIR" --strip
-          find "$LIBDIR" -type f -name '*.dll.a' -execdir sh -c 'ar x "{}" && rm "{}"' \;
-          (cd "$LIBDIR" && tar -cf "$DISTDIR/libchdr.tar" libchdr.*)
+          export STAGEDIR="$DISTDIR/stage"
+          mkdir -p "$STAGEDIR"
+          cmake --install "$BUILDDIR" --prefix "$DISTDIR" --strip
+          find "$DISTDIR/lib" \
+            \( -name 'libchdr.so*' -o -name 'libchdr*.dylib' \) \
+            \( -type f -o -type l \) -exec cp -P {} "$STAGEDIR/" \;
+          find "$BUILDDIR" -name 'libchdr.dll' -type f -exec cp {} "$STAGEDIR/" \;
+          (cd "$STAGEDIR" && tar -cf "$DISTDIR/libchdr.tar" libchdr.*)
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/libchdr.yml
+++ b/.github/workflows/libchdr.yml
@@ -69,6 +69,7 @@ jobs:
             --target chdr
       - name: Install complied libs
         # 'tar' to preserve symlinks for versioned .so/.dylib files
+        # Windows runtime DLLs are left in the build tree instead of dist/lib
         run: |
           export BUILDDIR="${{ github.workspace }}/build"
           export DISTDIR="${{ github.workspace }}/dist"

--- a/internal/osutil/load_library_windows.go
+++ b/internal/osutil/load_library_windows.go
@@ -3,14 +3,21 @@
 package osutil
 
 import (
+	"os"
 	"path/filepath"
 
 	"golang.org/x/sys/windows"
 )
 
 func LoadLibrary(name string) (handle uintptr, err error) {
-	if !filepath.IsAbs(name) && filepath.Ext(name) != ".dll" {
+	if filepath.Ext(name) != ".dll" {
 		name += ".dll"
+	}
+
+	if !filepath.IsAbs(name) {
+		if exe, exeErr := os.Executable(); exeErr == nil {
+			name = filepath.Join(filepath.Dir(exe), name)
+		}
 	}
 
 	h, err := windows.LoadLibraryEx(

--- a/internal/osutil/load_library_windows.go
+++ b/internal/osutil/load_library_windows.go
@@ -3,7 +3,6 @@
 package osutil
 
 import (
-	"os"
 	"path/filepath"
 
 	"golang.org/x/sys/windows"
@@ -14,17 +13,15 @@ func LoadLibrary(name string) (handle uintptr, err error) {
 		name += ".dll"
 	}
 
-	if !filepath.IsAbs(name) {
-		if exe, exeErr := os.Executable(); exeErr == nil {
-			name = filepath.Join(filepath.Dir(exe), name)
-		}
+	flags := uintptr(0)
+	if filepath.IsAbs(name) {
+		flags = windows.LOAD_WITH_ALTERED_SEARCH_PATH
 	}
 
 	h, err := windows.LoadLibraryEx(
 		name,
 		windows.Handle(0),
-		windows.LOAD_LIBRARY_SEARCH_DEFAULT_DIRS|
-			windows.LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR,
+		flags,
 	)
 	return uintptr(h), err
 }


### PR DESCRIPTION
Windows CHD support was broken: `WRN libchdr load failed, chd support is disabled err="The parameter is incorrect."`

Caused by two separate bugs, fixed here:
1) `ar x` on the MinGW import library (libchdr.dll.a) extracted a 56-byte COFF import stub and shipped that as libchdr.dll, so the real DLL was never packaged. The actual DLL lives in the build dir on Windows, so it's now taken from there.
2) LoadLibraryEx was called with a relative name, which requires a absolute path. Fixed in load_library_windows.go.

A working Windows artifact is available in my fork for verification: https://github.com/CatMe0w/ps3netsrv-go/releases