### PR TITLE
Skip automemlimit on non-linux platforms

### DIFF
--- a/cmd/ps3netsrv-go/server.go
+++ b/cmd/ps3netsrv-go/server.go
@@ -10,6 +10,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -260,6 +261,10 @@ func (sapp *serverApp) scanAndWarn() {
 }
 
 func (sapp *serverApp) setupRuntime() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+
 	_, err := memlimit.SetGoMemLimitWithOpts(memlimit.WithLogger(slog.Default()))
 	switch {
 	case errors.Is(err, nil),


### PR DESCRIPTION
This fixes such warnings on Windows and macOS:
```
ERR failed to set GOMEMLIMIT package=github.com/KimMachineGun/automemlimit/memlimit error="failed to set GOMEMLIMIT: cgroups is not supported on this system"
```