### PR TITLE
Fix libchdr binding for 32-bit platforms

### DIFF
--- a/pkg/fs/chd/libchdr.go
+++ b/pkg/fs/chd/libchdr.go
@@ -138,8 +138,7 @@ func (l *LibCHDR) readMeatadata(handle fileHandle) ([]CDMetadata, error) {
 			return nil, fmt.Errorf("idx %d: %w", idx, err)
 		}
 
-		tag := rawTag[:rawTagLen-1] // trim \0
-		item, err := ParseCDMetadata(tag)
+		item, err := ParseCDMetadata(rawTag[:rawTagLen])
 		if err != nil {
 			return nil, fmt.Errorf("idx %d: %w", idx, err)
 		}

--- a/pkg/fs/chd/libchdr_common.go
+++ b/pkg/fs/chd/libchdr_common.go
@@ -55,12 +55,17 @@ const (
 type FileHeader struct {
 	_ structs.HostLayout
 
-	Length       uint32 // of header in file
-	Version      uint32
-	Flags        uint32
-	Compression  [4]CompressionCodec
-	HunkBytes    uint32 // this is how much you should allocate for reading
-	TotalHunks   uint32 // this is used to limit amount of reads
+	Length      uint32 // of header in file
+	Version     uint32
+	Flags       uint32
+	Compression [4]CompressionCodec
+	HunkBytes   uint32 // this is how much you should allocate for reading
+	TotalHunks  uint32 // this is used to limit amount of reads
+	// C ABI alignment padding: C's uint64_t is 8-byte aligned (e.g. ARM AAPCS),
+	// so the C struct pads here; Go aligns uint64 to only 4 bytes on 32-bit, so
+	// without this every field from LogicalBytes on is misread on 32-bit (ARMv5).
+	// No-op on 64-bit (LogicalBytes is already at this offset there).
+	_            uint32
 	LogicalBytes uint64 // uncompressed size of source file
 	MetaOffset   uint64
 	MapOffset    uint64
@@ -140,11 +145,17 @@ type CDMetadata struct {
 }
 
 func ParseCDMetadata(tag []byte) (CDMetadata, error) {
+	// libchdr returns the metadata as a NUL-terminated C string and the
+	// reported length includes the terminator (and possible padding), so the
+	// last field otherwise ends up like "0\x00" and numeric parses fail.
+	tag = bytes.Trim(tag, "\x00 ")
+
 	var item CDMetadata
 	for len(tag) > 0 {
 		var rawItem []byte
 		rawItem, tag, _ = bytes.Cut(tag, []byte(" "))
 		key, value, _ := bytes.Cut(rawItem, []byte(":"))
+		value = bytes.Trim(value, "\x00 ")
 
 		switch string(key) {
 		case "TRACK":

--- a/pkg/fs/chd/libchdr_file_callbacks.go
+++ b/pkg/fs/chd/libchdr_file_callbacks.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xakep666/ps3netsrv-go/internal/osutil/dynamiclibs"
 )
 
-// fileCallbacks are called by libchdr itself to outsource i/o operations
+// fileCallbacks are called by libchdr ituserdata to outsource i/o operations
 type fileCallbacks struct {
 	_ structs.HostLayout
 
@@ -27,6 +27,7 @@ type fileCallbacks struct {
 func newFileCallbacks(log *slog.Logger) *fileCallbacks {
 	// dynamiclibs.Handle used to propagate a Go value through C code without it's being garbage-collected
 	return &fileCallbacks{
+		// signature: uint64_t fsize(void* userdata);
 		fsize: dynamiclibs.NewCallback(func(_ dynamiclibs.CDecl, userdata dynamiclibs.Handle) uint64 {
 			f := userdata.Value().(handler.File)
 			ret, err := f.Seek(0, io.SeekEnd)
@@ -36,19 +37,22 @@ func newFileCallbacks(log *slog.Logger) *fileCallbacks {
 			}
 			return uint64(ret)
 		}),
-		fread: dynamiclibs.NewCallback(func(_ dynamiclibs.CDecl, target *byte, size, count int64, userdata dynamiclibs.Handle) int64 {
+		// signature: size_t fread(void *target, size_t size, size_t count, void* userdata);
+		// Go's analog for size_t is uint.
+		fread: dynamiclibs.NewCallback(func(_ dynamiclibs.CDecl, target *byte, size, count uint, userdata dynamiclibs.Handle) uint {
 			f := userdata.Value().(handler.File)
 			n, err := f.Read(unsafe.Slice(target, count*size))
 			switch {
 			case errors.Is(err, nil):
-				return int64(n)
+				return uint(n)
 			case errors.Is(err, io.EOF):
 				return 0
 			default:
 				log.Error("chd: read failed", logutil.ErrorAttr(err), slog.String("name", f.Name()))
-				return int64(extractSysErrCode(err))
+				return uint(extractSysErrCode(err))
 			}
 		}),
+		// signatrue: int fclose(void *userdata);
 		fclose: dynamiclibs.NewCallback(func(_ dynamiclibs.CDecl, userdata dynamiclibs.Handle) int {
 			defer userdata.Delete()
 
@@ -60,6 +64,7 @@ func newFileCallbacks(log *slog.Logger) *fileCallbacks {
 			}
 			return 0
 		}),
+		// signature: int fseek(void *userdata, int64_t offset, int whence);
 		fseek: dynamiclibs.NewCallback(func(_ dynamiclibs.CDecl, userdata dynamiclibs.Handle, offset int64, whence int) int {
 			f := userdata.Value().(handler.File)
 			_, err := f.Seek(offset, whence)


### PR DESCRIPTION
* Force strip NUL and space when parsing CHD CD metadata tag
* Fix signature of 'fread' callback: use arch-sized integers where necessary
* Force 64-bit alignment for 'FileHeader.LogicalBytes' field